### PR TITLE
修复 动态更改页码的渲染问题

### DIFF
--- a/xlPaging.js
+++ b/xlPaging.js
@@ -38,6 +38,7 @@
 			}
 			//如果只有一页并且设置为不显示，则不进行渲染
 			if(!showOne && pageNum === 1){
+				me.element.html('');
 				return '';
 			}
             content.push("<ul>");


### PR DESCRIPTION
动态渲染分页时，当 pageNum = 1 并且 showOne = 0 ，插件将直接返回空字符从而不进行渲染，而问题在于，此举未将之前已渲染的分页清空，导致不正常结果。